### PR TITLE
[#3] Error in docker-compose build due to OpenJDK update.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,7 @@ ARG USER_GID=$USER_UID
 USER root
 RUN apt update \
     && export DEBIAN_FRONTEND=noninteractive \
+    && LANG=C LC_ALL=C apt-get -y install --no-install-recommends openjdk-17-jre-headless \
     && LANG=C LC_ALL=C apt-get -y install --no-install-recommends \    
     plantuml \
     pandoc \


### PR DESCRIPTION
The order of dependencies is incorrect due to OpenJDK changes.