### PR TITLE
[#12] Error in make lint due to mypy update

### DIFF
--- a/src/niceapi/io/_webapi_default.py
+++ b/src/niceapi/io/_webapi_default.py
@@ -6,20 +6,20 @@ from logging import INFO, Logger, getLogger
 from typing import Any, Dict, Optional, Union
 
 import requests
-import requests.packages.urllib3
+import urllib3
 from requests.adapters import HTTPAdapter
 
 # disable warning
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-from requests.packages.urllib3.poolmanager import PoolManager
-from requests.packages.urllib3.util.ssl_ import create_urllib3_context
+from urllib3.exceptions import InsecureRequestWarning
+from urllib3.poolmanager import PoolManager
+from urllib3.util.ssl_ import create_urllib3_context
 
 from ..util._tools import _file_update, _logger_setup
 from .webapi_base import BODY_T, JSON_T, TLS_ROOT_CERTS_T, WebAPIBase
 
 VERIFY_CERT_T = Union[str, bool, None]
 
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+urllib3.disable_warnings(InsecureRequestWarning)
 
 CIPHERS: str = (
     "ECDHE-ECDSA-AES256-GCM-SHA384:"


### PR DESCRIPTION
An error occurred in make lint when mypy was upgraded from 1.5.1 to 1.6.0.

src/niceapi/io/_webapi_default.py:9: error: Library stubs not installed for "requests.packages.urllib3" [import-untyped] src/niceapi/io/_webapi_default.py:13: error: Library stubs not installed for "requests.packages.urllib3.exceptions" [import-untyped] src/niceapi/io/_webapi_default.py:14: error: Library stubs not installed for "requests.packages.urllib3.poolmanager" [import-untyped] src/niceapi/io/_webapi_default.py:15: error: Library stubs not installed for "requests.packages.urllib3.util.ssl_" [import-untyped] 

Change requests.packages.urllib3 to urllib3.